### PR TITLE
Update gemspec version to ./dijkstra-0.1.0.gem in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ob.write_to_file('shortestpath.out')
 $ git clone git://github.com/oscartanner/dijkstra.gem.git
 $ cd dijkstra.gem
 $ gem build dijkstra.gemspec
-$ gem install ./dijkstra-0.0.1.gem
+$ gem install ./dijkstra-0.1.0.gem
 $ ruby app.rb # testing
 $ Cost = 6
 $ Shortest Path  = [1,2,4,3]=> true


### PR DESCRIPTION
Please update readme's gemspec version to ./dijkstra-0.1.0.gem to avoid error while doing manual installation.

 (ERROR:  Could not find a valid gem './dijkstra-0.0.1.gem' (>= 0) in any repository) 
